### PR TITLE
Simplify main.go to basic Hello World example

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,17 +2,8 @@ package main
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/BullionBear/sequex/pkg/exchange/binance"
 )
 
 func main() {
-	c := binance.NewWSStreamClient(binance.DefaultConfig())
-	unsubscribe, _ := c.SubscribeToDiffDepthWithCallback("ETHUSDT", "@100ms", func(data *binance.WSDiffDepthData) error {
-		fmt.Println(data)
-		return nil
-	})
-	time.Sleep(10 * time.Second)
-	unsubscribe()
+	fmt.Println("Hello, World!")
 }


### PR DESCRIPTION
## Summary
This PR simplifies the `cmd/main.go` file to a basic "Hello, World!" example, removing the complex Binance WebSocket client implementation.

## Changes
- Simplified `cmd/main.go` to print "Hello, World!" instead of running WebSocket client
- Removed unused imports (`time` and `github.com/BullionBear/sequex/pkg/exchange/binance`)
- Cleaned up the main function to be more straightforward

## Purpose
This change makes the main.go file more approachable and easier to understand for new users, while keeping the complex WebSocket functionality available in the package for those who need it.

## Testing
- [x] Code compiles successfully
- [x] Basic functionality works as expected